### PR TITLE
Bug fixes, changes to structure

### DIFF
--- a/DOMEditor/html_edits.py
+++ b/DOMEditor/html_edits.py
@@ -1,3 +1,5 @@
+from .utils import assign_attributes
+
 """This file includes the function used to edit some DOM
 attributes of the chosen html page (edit_html).
 It uses Beautifulsoup to parse the DOM:
@@ -20,7 +22,7 @@ def edit_html(soup):
     So far it only adds some stylings to elements
     that would convert poorly to pdf
     without the changes.
-    
+
     --- Add more stylings and changes to the function as needed ---
 
     Args:
@@ -31,9 +33,12 @@ def edit_html(soup):
         [soup]: bs4 object after the modifications to
         its html content
     """
-    
+
     # Change body font size
     body = soup.body
+    # small error check jic, this should exist for any valid page
+    if body == None:
+        return ""
     body["style"] = "font-size:{};".format(BODY_FONT_SIZE)
 
     # Stop hiding the insides of collapsables. May conflict with old collapsables
@@ -59,19 +64,5 @@ def edit_html(soup):
                 tab_final_style = tab_style
             assign_attributes(tab, style=tab_final_style)
             tab_counter += 1
-            
+
     return soup
-
-
-
-def assign_attributes(object, **kwargs):
-    """Assigns an arbitray amount of key / values to an object.
-    Intented use is to add attributes to an html tag in a bs4 object.
-
-    Args:
-        object: any bs4 object containing an html element.
-        intented args should be in the form key=value
-        f.ex: assign_attributes(htmlTag, style='font-size:35px;')
-    """
-    for key in kwargs:
-        object[key] = kwargs[key]

--- a/DOMEditor/utils.py
+++ b/DOMEditor/utils.py
@@ -1,0 +1,73 @@
+import datetime
+import re
+
+
+def printWTime(string):
+    """Simple function to add the actual time to the start of a string"""
+    print(datetime.datetime.now().strftime("%H:%M:%S") + " - " + string)
+
+
+def is_valid_filename(filename):
+    """Check if a file has a valid filename (valid chars and max length gotten from
+    stack overflow and other sources, may be wrong)"""
+    # Added some accents, ö and stuff like that is still verboten
+    valid_chars = '-_.() abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789àèéíóòúüÀÈÉÍÒÓÚÜ'
+    if len(filename) > 260:
+        return False
+    for char in filename:
+        if char not in valid_chars:
+            return False
+    return True
+
+
+def has_extension(string, ext):
+    """Returns true/false if a string (supposedly a filename) has an extension or not.
+    F.ex: index.html has_extension html -> True. hello.pdf has_extension txt -> False"""
+    if (ext[0] != "."):
+        ext = "." + ext
+    if (string[-len(ext):] != ext):
+        return False
+    return True
+
+
+def assign_attributes(object, **kwargs):
+    """Assigns an arbitray amount of key / values to an object.
+    Intented use is to add attributes to an html tag in a bs4 object.
+
+    Args:
+        object: any bs4 object containing an html element.
+        intented args should be in the form key=value
+        f.ex: assign_attributes(htmlTag, style='font-size:35px;')
+    """
+    for key in kwargs:
+        object[key] = kwargs[key]
+
+
+"""Changes relative src/href for the absolute path in the filesystem,
+used because wkhtmltopdf doesnt like importing relative stuff.
+Base_path is obtained from the function calling this one.
+Created to fix something that isnt broken (at least so far), so unused"""
+
+
+def absolutize_url_paths(soup, base_path):
+    all_path_elements = soup.find_all(href=True) + soup.find_all(src=True)
+    non_url_non_svg = '^(?!http|data:)'
+    for element in all_path_elements:
+        if (has_attr(element, "src")):
+            element["src"] = re.sub(non_url_non_svg, base_path, element["src"])
+        elif (has_attr(element, "href")):
+            element["href"] = re.sub(
+                non_url_non_svg, base_path, element["href"])
+    return soup
+
+
+"""Helper function, it does what hasattr should for bs4 objects.
+Just check if the desired attribute exists in an object."""
+
+
+def has_attr(object, attr):
+    try:
+        object[attr]
+        return True
+    except:
+        return False

--- a/DOMEditor/utils.py
+++ b/DOMEditor/utils.py
@@ -20,14 +20,18 @@ def is_valid_filename(filename):
     return True
 
 
-def has_extension(string, ext):
+def has_extension(string, exts):
     """Returns true/false if a string (supposedly a filename) has an extension or not.
     F.ex: index.html has_extension html -> True. hello.pdf has_extension txt -> False"""
-    if (ext[0] != "."):
-        ext = "." + ext
-    if (string[-len(ext):] != ext):
-        return False
-    return True
+    if (isinstance(exts,str)):
+        exts = [exts]
+    has_extension = False
+    for ext in exts:
+        if (ext[0] != "."):
+            ext = "." + ext
+        if (string[-len(ext):] == ext):
+            has_extension = True
+    return has_extension
 
 
 def assign_attributes(object, **kwargs):
@@ -46,12 +50,16 @@ def assign_attributes(object, **kwargs):
 """Changes relative src/href for the absolute path in the filesystem,
 used because wkhtmltopdf doesnt like importing relative stuff.
 Base_path is obtained from the function calling this one.
-Created to fix something that isnt broken (at least so far), so unused"""
+Should absolutize all types of relative paths and leave http*: / data: paths untouched.
+There may be some exceptions I have not considered, however it works for my use cases...
+!!!!Do not use if the site has some absolute and some relative paths!!!!
+If that's the case, use ^(?!http|data:) as regex for most of the cases 
+then create another for the rest or w/e"""
 
 
 def absolutize_url_paths(soup, base_path):
     all_path_elements = soup.find_all(href=True) + soup.find_all(src=True)
-    non_url_non_svg = '^(?!http|data:)'
+    non_url_non_svg = '^(?!http|data:)|^\/'
     for element in all_path_elements:
         if (has_attr(element, "src")):
             element["src"] = re.sub(non_url_non_svg, base_path, element["src"])

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM surnet/alpine-python-wkhtmltopdf:3.9.0-0.12.6-small
+
+# Where the inputs will be found in the container
+# Sync with the one used when using docker run
+ENV INPUT_DIR="input"
+
+WORKDIR /usr/src/html2pdf
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# For the tmp files used
+VOLUME "/tmp/"
+
+COPY . .
+
+ENTRYPOINT ["python3", "ioc_html2pdf.py"]
+
+# Default filename used if no args
+CMD ["index.html"]

--- a/html2pdf.sh
+++ b/html2pdf.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Small script to run docker with the required params for this image to work
+if [[ $(which docker) && $(docker --version) ]]; then
+    docker run -it \
+    --mount type=bind,source=$(pwd),target=/usr/src/html2pdf/input,bind-propagation=rslave \
+    -v $(pwd):/usr/src/html2pdf/output \
+    -u $(id -u):$(id -g) \
+    ramonvd/pdfconvert:latest "$@"
+else
+    echo "No tens Docker instal·lat. Cal que l'instal·lis primer, seguint les instruccions a: https://docs.docker.com/engine/install/ubuntu/"
+fi
+
+

--- a/ioc_html2pdf.py
+++ b/ioc_html2pdf.py
@@ -16,8 +16,9 @@ DEFAULT_OUTPUT_FILENAME = "output"
 DEFAULT_BASEDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 # Non changeable as of now
 DEFAULT_OUTPUT_DIR = os.path.join(DEFAULT_BASEDIR, "output")
-#Just for Docker, probably set via env variable
-DEFAULT_INPUT_DIR = os.path.join(DEFAULT_BASEDIR, "")
+#Just for Docker, set via env in the Dockerfile
+docker_dir = os.getenv("INPUT_DIR","")
+DEFAULT_INPUT_DIR = os.path.join(DEFAULT_BASEDIR, docker_dir)
 
 def parse_args(args):
     """ Returns a dict with the input/output values, or an error key if there was an error.

--- a/ioc_html2pdf.py
+++ b/ioc_html2pdf.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 import sys
-import datetime
 import os
 from tempfile import NamedTemporaryFile
 from bs4 import BeautifulSoup
-from DOMEditor.edit_html import edit_html
+from DOMEditor.html_edits import edit_html
+from DOMEditor.utils import printWTime, has_extension, is_valid_filename
 import pdfkit
 
 # Shows messages about the actions taken by the program
@@ -13,32 +13,10 @@ VERBOSE = True
 # Output files will be called thisX.pdf (f.ex: output1.pdf, output2.pdf...)
 # unless specified otherwise
 DEFAULT_OUTPUT_FILENAME = "output"
+DEFAULT_BASEDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 # Non changeable as of now
-DEFAULT_OUTPUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
+DEFAULT_OUTPUT_DIR = os.path.join(DEFAULT_BASEDIR, "output")
 
-def printWTime(string):
-    """Simple function to add the actual time to the start of a string"""
-    print(datetime.datetime.now().strftime("%H:%M:%S") + " - " + string)
-
-def is_valid_filename(filename):
-    """Check if a file has a valid filename (valid chars and max length gotten from
-    stack overflow and other sources, may be wrong)"""
-    valid_chars = '-_.() abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-    if filename.length > 260:
-        return "File path is too long"
-    for char in filename:
-        if char not in valid_chars:
-            return "Filename contains illegal characters"
-    return ""
-
-def has_extension(string, ext):
-    """Returns true/false if a string (supposedly a filename) has an extension or not.
-    F.ex: index.html has_extension html -> True. hello.pdf has_extension txt -> False"""
-    if (ext[0] != "."):
-        ext = "." + ext
-    if (string[-len(ext):] != ext):
-        return False
-    return True
 
 def parse_args(args):
     """ Returns a dict with the input/output values, or an error key if there was an error.
@@ -56,15 +34,23 @@ def parse_args(args):
             inputs = inputs[0].split(",")
             for input in inputs[0]:
                 input.strip()
-        data["inputs"] = [input.strip() for input in inputs]
+        data["inputs"] = list(
+            filter(is_valid_filename, [input.strip() for input in inputs]))
+
+        if (len(data["inputs"]) < 1):
+            data["error"] = "Invalid input file. Please input a .html file with correct syntax."
+
         if (len(args) > 2):
             data["output"] = args[-1]
     return data
+
 
 class CouldntEditHtmlException(Exception):
     pass
 
 # Specific output names are in, need to handle multiple inputs
+
+
 def parse_document(args):
     parsed_args = parse_args(args)
     error_msg = ""
@@ -87,18 +73,21 @@ def parse_document(args):
         try:
             os.mkdir(DEFAULT_OUTPUT_DIR)
         except OSError:
-            print ("Cannot create output directory, please check directory permissions")
+            print("Cannot create output directory, please check directory permissions")
             return False
 
     # Output filename will have .pdf appended afterwards, remove it if it exists already
     # This will not check for weird output filenames, maybe apply is_valid_filename...
-    final_default_output = os.path.join(DEFAULT_OUTPUT_DIR, DEFAULT_OUTPUT_FILENAME)
+    final_default_output = os.path.join(
+        DEFAULT_OUTPUT_DIR, DEFAULT_OUTPUT_FILENAME)
     if "output" in parsed_args:
         output_name = parsed_args["output"]
         if has_extension(output_name, "pdf"):
-            final_default_output = os.path.join(DEFAULT_OUTPUT_DIR, output_name[:-4])
+            final_default_output = os.path.join(
+                DEFAULT_OUTPUT_DIR, output_name[:-4])
         else:
-            final_default_output = os.path.join(DEFAULT_OUTPUT_DIR, output_name)
+            final_default_output = os.path.join(
+                DEFAULT_OUTPUT_DIR, output_name)
 
     output_filename = final_default_output
 
@@ -112,24 +101,32 @@ def parse_document(args):
     try:
         with open(filename) as fp:
             soup = BeautifulSoup(fp, "html.parser")
+            # UNUSED, apparently not needed. Maybe with docker.
+            # abs_path_soup = absolutize_url_paths(
+            #   soup, "file://" + DEFAULT_BASEDIR + os.sep)
             printWTime("Started editing html elements.") if (VERBOSE) else None
             modifiedSoup = edit_html(soup)
-            printWTime("Finished editing html elements.") if (VERBOSE) else None
+            printWTime("Finished editing html elements.") if (
+                VERBOSE) else None
     except IOError:
         print("File %s is not accessible" % filename)
         return False
 
     # Convert bs4 object to pdf and write it to file
     try:
-        with NamedTemporaryFile(mode="w+t", suffix=".html") as fp:
+        with NamedTemporaryFile(mode="w+t", dir="./", suffix=".html") as fp:
             if (modifiedSoup == ""):
-                raise CouldntEditHtmlException("Unable to parse html from: %s" % filename)
+                raise CouldntEditHtmlException(
+                    "Unable to parse html from: %s" % filename)
             fp.write(str(modifiedSoup))
             try:
-                printWTime("Starting html to pdf conversion...") if (VERBOSE) else None
-                pdfkit.from_file(fp.name, output_filename)
+                printWTime("Starting html to pdf conversion...") if (
+                    VERBOSE) else None
+                options = {"enable-local-file-access": "",
+                           'disable-javascript': True}
+                pdfkit.from_file(fp.name, output_filename, options=options)
                 printWTime("""Finished html to pdf conversion.
-Output file is at %s""" %output_filename) if (VERBOSE) else None
+Output file is at %s""" % output_filename) if (VERBOSE) else None
                 return True
             except Exception as e:
                 print("Error while converting to pdf: %s" % str(e))
@@ -144,5 +141,3 @@ Output file is at %s""" %output_filename) if (VERBOSE) else None
 
 if __name__ == '__main__':
     parse_document(sys.argv)
-
-


### PR DESCRIPTION
Small changes to structure to reflect better what can be edited and
where the aux functions are.

Some fun bugfixes (like having to check that body exists in an html...
it should but w/e, or valid filenames excluding letters with accents
(not sure if its very legal and very cool but my usecases will probably
include some, so I do have to accept them)

The important stuff:
Okay, so wkhtmltopdf wasn't working with a big page that had relative
imports and pretty complex structure/images/stylesheets/scripts, etc.

- Apparently, this was related to the page having relative imports
instead of absolute ones. Created a small function to change them but it
did not help.

- Tried some flags for pdfkit, etc. Still not working.

- Experimented with wkhtmltopdf in the cli. It gives better error info
that way. Apparently the error was because a js for a video loader
embedded something in the page dynamically (an iframe?) with some
attribute (I think x-origin)=file:///youtubei/v1/log_event={big json
with some API uuid}.
It put file:// since the script was using window.location.origin to get
the path.
So in the end wkhtml thought it was something it had to load so it tried
and failed hard, and that was what was borking everything.

- Removed js from loading when doing the conversion, it shouldn't be
needed.

- Everything seems to work so far, some warnings from the stylesheets
using url(non found import that only exists in the ioc server) but
nothing serious. Removed absolute imports.

- Need to check if this all works fine with docker